### PR TITLE
SQLite force index support

### DIFF
--- a/lib/DBR/Misc/Connection.pm
+++ b/lib/DBR/Misc/Connection.pm
@@ -158,4 +158,7 @@ sub _wrap{
 
       return wantarray?@_:$_[0];
 }
+
+sub force_index_syntax { 'FORCE INDEX (', ')' }
+
 1;

--- a/lib/DBR/Misc/Connection/SQLite.pm
+++ b/lib/DBR/Misc/Connection/SQLite.pm
@@ -16,4 +16,6 @@ sub getSequenceValue{
 
 sub can_lock { 0 }
 
+sub force_index_syntax { 'INDEXED BY ' }
+
 1;

--- a/lib/DBR/Query/Select.pm
+++ b/lib/DBR/Query/Select.pm
@@ -44,7 +44,10 @@ sub sql{
       my $fields = join(',', map { $_->sql( $conn ) } @{$self->{fields}} );
 
       $sql = "SELECT $fields FROM $tables";
-      $sql .= ' FORCE INDEX (' . $conn->quote_identifier($self->{force_index}) . ') ' if $self->{force_index};
+      if ($self->{force_index}) {
+          my ($prefix, $postfix) = $conn->force_index_syntax;
+          $sql .= ' ' . $prefix . $conn->quote_identifier($self->{force_index}) . ($postfix // '');
+      }
       $sql .= ' WHERE ' . $self->{where}->sql($conn) if $self->{where};
       if (@{ $self->{orderby} || [] }) {
           $sql .= ' ORDER BY ' . join(', ', map { $_->sql($conn) } @{ $self->{orderby} || [] });


### PR DESCRIPTION
SQLite uses "INDEXED BY", not "FORCE INDEX".  Verified using the gt-core testsuite.