### PR TITLE
Prefix value errors with code, don't include values in message

### DIFF
--- a/lib/DBR/Common.pm
+++ b/lib/DBR/Common.pm
@@ -98,17 +98,22 @@ sub _warn       {
 
 sub _error     {
     my $s = shift->_session;
+	my $code = shift;
     my $message = shift;
+	unless (defined $message) {
+		$message = $code;
+		$code = 'internal_error';
+	}
 
     if($s){
-	$s->_log( $message, 'ERROR' );
+		$s->_log( $message, 'ERROR' );
     }else{
-	print STDERR "DBR ERROR: $message\n";
+		print STDERR "DBR ERROR: $message\n";
     }
     
     if( $s && $s->use_exceptions ){
-	local $Carp::CarpLevel = 1;
-	croak $message;
+		local $Carp::CarpLevel = 1;
+		croak "$code: $message";
     }
     
     return undef;

--- a/lib/DBR/Query/Insert.pm
+++ b/lib/DBR/Query/Insert.pm
@@ -14,104 +14,104 @@ sub _params    { qw (sets tables where limit quiet_error) }
 sub _reqparams { qw (sets tables) }
 
 sub sets{
-      my $self = shift;
-      exists( $_[0] )  or return wantarray?( @$self->{sets} ) : $self->{sets} || undef;
-      my @sets = $self->_arrayify(@_);
-      scalar(@sets) || croak('must provide at least one set');
+    my $self = shift;
+    exists( $_[0] )  or return wantarray?( @$self->{sets} ) : $self->{sets} || undef;
+    my @sets = $self->_arrayify(@_);
+    scalar(@sets) || croak('must provide at least one set');
 
-      for (@sets){
-	    ref($_) eq 'DBR::Query::Part::Set' || croak('arguments must be Sets');
-      }
-      
-      $self->{sets} = \@sets;
-      
-      $self->_check_fields;
+    for (@sets) {
+        ref($_) eq 'DBR::Query::Part::Set' || croak('arguments must be Sets');
+    }
 
-      return 1;
+    $self->{sets} = \@sets;
+
+    $self->_check_fields;
+
+    return 1;
 }
 
 sub _check_fields{
-      my $self = shift;
+    my $self = shift;
 
-      # Make sure we have sets for all required fields
-      # It may be slightly more efficient to enforce this in ::Interface::Object->insert, but it seems more correct here.
+    # Make sure we have sets for all required fields
+    # It may be slightly more efficient to enforce this in ::Interface::Object->insert, but it seems more correct here.
 
-      return 0 unless $self->{sets} && $self->{tables};
+    return 0 unless $self->{sets} && $self->{tables};
 
-      my %fids = map { $_->field->field_id => 1 } grep { defined $_->field->field_id } @{ $self->{sets} };
-      
-      my $reqfields = $self->primary_table->req_fields();
-      my @missing;
-      foreach my $field ( grep { !$fids{ $_->field_id } } @$reqfields ){
-            if ( defined ( my $v = $field->default_val ) ){
-                  my $value = $field->makevalue( $v ) or croak "failed to build value object for " . $field->name;
-                  my $set = DBR::Query::Part::Set->new($field,$value) or confess 'failed to create set object';
-                  push @{ $self->{sets} }, $set;
-            }else{
-                  push @missing, $field;
-            }
-      
-      }
-      if(@missing){
-	    croak "Invalid insert. Missing fields (" .
-	    join(', ', map { $_->name } @missing) . ")";
-      }
-      $self->{_fields_checked} = 1;
+    my %fids = map { $_->field->field_id => 1 } grep { defined $_->field->field_id } @{ $self->{sets} };
+
+    my $reqfields = $self->primary_table->req_fields();
+    my @missing;
+    foreach my $field ( grep { !$fids{ $_->field_id } } @$reqfields ) {
+        if ( defined ( my $v = $field->default_val ) ) {
+            my $value = $field->makevalue( $v ) or croak "failed to build value object for " . $field->name;
+            my $set = DBR::Query::Part::Set->new($field,$value) or confess 'failed to create set object';
+            push @{ $self->{sets} }, $set;
+        }else{
+            push @missing, $field;
+        }
+
+    }
+    if (@missing) {
+        croak "Invalid insert. Missing fields (" .
+            join(', ', map { $_->name } @missing) . ")";
+    }
+    $self->{_fields_checked} = 1;
 }
 
 sub _validate_self{
-      my $self = shift;
+    my $self = shift;
 
-      @{$self->{tables}} == 1 or croak "Must have exactly one table";
-      $self->{sets} or croak "Must have at least one set";
-      
-      $self->_check_fields unless $self->{_fields_checked};
-      
-      return 1;
+    @{$self->{tables}} == 1 or croak "Must have exactly one table";
+    $self->{sets} or croak "Must have at least one set";
+
+    $self->_check_fields unless $self->{_fields_checked};
+
+    return 1;
 }
 
 sub sql{
-      my $self = shift;
+    my $self = shift;
 
-      my $conn   = $self->instance->connect('conn') or return $self->_error('failed to connect');
-      my $sql;
-      my $tables = join(',', map {$_->sql($conn)} @{$self->{tables}} );
+    my $conn   = $self->instance->connect('conn') or return $self->_error('failed to connect');
+    my $sql;
+    my $tables = join(',', map {$_->sql($conn)} @{$self->{tables}} );
 
-      my @fields;
-      my @values;
-      for ( @{$self->{sets}} ) {
-	    push @fields, $_->field->sql( $conn );
-	    push @values, $_->value->sql( $conn );
-      }
+    my @fields;
+    my @values;
+    for ( @{$self->{sets}} ) {
+        push @fields, $_->field->sql( $conn );
+        push @values, $_->value->sql( $conn );
+    }
 
-      $sql = "INSERT INTO $tables (" . join (', ', @fields) . ') values (' . join (', ', @values) . ')';
+    $sql = "INSERT INTO $tables (" . join (', ', @fields) . ') values (' . join (', ', @values) . ')';
 
-      $sql .= ' WHERE ' . $self->{where}->sql( $conn ) if $self->{where};
-      $sql .= ' FOR UPDATE'                            if $self->{lock} && $conn->can_lock;
-      $sql .= ' LIMIT ' . $self->{limit}               if $self->{limit};
+    $sql .= ' WHERE ' . $self->{where}->sql( $conn ) if $self->{where};
+    $sql .= ' FOR UPDATE'                            if $self->{lock} && $conn->can_lock;
+    $sql .= ' LIMIT ' . $self->{limit}               if $self->{limit};
 
-      $self->_logDebug2( $sql );
-      return $sql;
+    $self->_logDebug2( $sql );
+    return $sql;
 }
 
 sub run{
-      my $self = shift;
-      my %params = @_;
+    my $self = shift;
+    my %params = @_;
 
-      my $conn = $self->instance->connect('conn') or return $self->_error('failed to connect');
+    my $conn = $self->instance->connect('conn') or return $self->_error('failed to connect');
 
-      $conn->quiet_next_error if $self->quiet_error;
-      $conn->prepSequence() or confess 'Failed to prepare sequence';
+    $conn->quiet_next_error if $self->quiet_error;
+    $conn->prepSequence() or confess 'Failed to prepare sequence';
 
-      my $rows = $conn->do( $self->sql ) or return $self->quiet_error ? undef : $self->_error("Insert failed: $DBI::errstr");
+    my $rows = $conn->do( $self->sql ) or return $self->quiet_error ? undef : $self->_error("error: Insert failed - $DBI::errstr");
 
-      # Tiny optimization: if we are being executed in a void context, then we
-      # don't care about the sequence value. save the round trip and reduce latency.
-      return 1 if $params{void};
+    # Tiny optimization: if we are being executed in a void context, then we
+    # don't care about the sequence value. save the round trip and reduce latency.
+    return 1 if $params{void};
 
-      my ($sequenceval) = $conn->getSequenceValue();
+    my ($sequenceval) = $conn->getSequenceValue();
 
-      return $sequenceval;
+    return $sequenceval;
 
 }
 

--- a/lib/DBR/Query/Insert.pm
+++ b/lib/DBR/Query/Insert.pm
@@ -14,104 +14,104 @@ sub _params    { qw (sets tables where limit quiet_error) }
 sub _reqparams { qw (sets tables) }
 
 sub sets{
-    my $self = shift;
-    exists( $_[0] )  or return wantarray?( @$self->{sets} ) : $self->{sets} || undef;
-    my @sets = $self->_arrayify(@_);
-    scalar(@sets) || croak('must provide at least one set');
+      my $self = shift;
+      exists( $_[0] )  or return wantarray?( @$self->{sets} ) : $self->{sets} || undef;
+      my @sets = $self->_arrayify(@_);
+      scalar(@sets) || croak('must provide at least one set');
 
-    for (@sets) {
-        ref($_) eq 'DBR::Query::Part::Set' || croak('arguments must be Sets');
-    }
+      for (@sets){
+	    ref($_) eq 'DBR::Query::Part::Set' || croak('arguments must be Sets');
+      }
+      
+      $self->{sets} = \@sets;
+      
+      $self->_check_fields;
 
-    $self->{sets} = \@sets;
-
-    $self->_check_fields;
-
-    return 1;
+      return 1;
 }
 
 sub _check_fields{
-    my $self = shift;
+      my $self = shift;
 
-    # Make sure we have sets for all required fields
-    # It may be slightly more efficient to enforce this in ::Interface::Object->insert, but it seems more correct here.
+      # Make sure we have sets for all required fields
+      # It may be slightly more efficient to enforce this in ::Interface::Object->insert, but it seems more correct here.
 
-    return 0 unless $self->{sets} && $self->{tables};
+      return 0 unless $self->{sets} && $self->{tables};
 
-    my %fids = map { $_->field->field_id => 1 } grep { defined $_->field->field_id } @{ $self->{sets} };
-
-    my $reqfields = $self->primary_table->req_fields();
-    my @missing;
-    foreach my $field ( grep { !$fids{ $_->field_id } } @$reqfields ) {
-        if ( defined ( my $v = $field->default_val ) ) {
-            my $value = $field->makevalue( $v ) or croak "failed to build value object for " . $field->name;
-            my $set = DBR::Query::Part::Set->new($field,$value) or confess 'failed to create set object';
-            push @{ $self->{sets} }, $set;
-        }else{
-            push @missing, $field;
-        }
-
-    }
-    if (@missing) {
-        croak "Invalid insert. Missing fields (" .
-            join(', ', map { $_->name } @missing) . ")";
-    }
-    $self->{_fields_checked} = 1;
+      my %fids = map { $_->field->field_id => 1 } grep { defined $_->field->field_id } @{ $self->{sets} };
+      
+      my $reqfields = $self->primary_table->req_fields();
+      my @missing;
+      foreach my $field ( grep { !$fids{ $_->field_id } } @$reqfields ){
+            if ( defined ( my $v = $field->default_val ) ){
+                  my $value = $field->makevalue( $v ) or croak "failed to build value object for " . $field->name;
+                  my $set = DBR::Query::Part::Set->new($field,$value) or confess 'failed to create set object';
+                  push @{ $self->{sets} }, $set;
+            }else{
+                  push @missing, $field;
+            }
+      
+      }
+      if(@missing){
+	    croak "Invalid insert. Missing fields (" .
+	    join(', ', map { $_->name } @missing) . ")";
+      }
+      $self->{_fields_checked} = 1;
 }
 
 sub _validate_self{
-    my $self = shift;
+      my $self = shift;
 
-    @{$self->{tables}} == 1 or croak "Must have exactly one table";
-    $self->{sets} or croak "Must have at least one set";
-
-    $self->_check_fields unless $self->{_fields_checked};
-
-    return 1;
+      @{$self->{tables}} == 1 or croak "Must have exactly one table";
+      $self->{sets} or croak "Must have at least one set";
+      
+      $self->_check_fields unless $self->{_fields_checked};
+      
+      return 1;
 }
 
 sub sql{
-    my $self = shift;
+      my $self = shift;
 
-    my $conn   = $self->instance->connect('conn') or return $self->_error('failed to connect');
-    my $sql;
-    my $tables = join(',', map {$_->sql($conn)} @{$self->{tables}} );
+      my $conn   = $self->instance->connect('conn') or return $self->_error('failed to connect');
+      my $sql;
+      my $tables = join(',', map {$_->sql($conn)} @{$self->{tables}} );
 
-    my @fields;
-    my @values;
-    for ( @{$self->{sets}} ) {
-        push @fields, $_->field->sql( $conn );
-        push @values, $_->value->sql( $conn );
-    }
+      my @fields;
+      my @values;
+      for ( @{$self->{sets}} ) {
+	    push @fields, $_->field->sql( $conn );
+	    push @values, $_->value->sql( $conn );
+      }
 
-    $sql = "INSERT INTO $tables (" . join (', ', @fields) . ') values (' . join (', ', @values) . ')';
+      $sql = "INSERT INTO $tables (" . join (', ', @fields) . ') values (' . join (', ', @values) . ')';
 
-    $sql .= ' WHERE ' . $self->{where}->sql( $conn ) if $self->{where};
-    $sql .= ' FOR UPDATE'                            if $self->{lock} && $conn->can_lock;
-    $sql .= ' LIMIT ' . $self->{limit}               if $self->{limit};
+      $sql .= ' WHERE ' . $self->{where}->sql( $conn ) if $self->{where};
+      $sql .= ' FOR UPDATE'                            if $self->{lock} && $conn->can_lock;
+      $sql .= ' LIMIT ' . $self->{limit}               if $self->{limit};
 
-    $self->_logDebug2( $sql );
-    return $sql;
+      $self->_logDebug2( $sql );
+      return $sql;
 }
 
 sub run{
-    my $self = shift;
-    my %params = @_;
+      my $self = shift;
+      my %params = @_;
 
-    my $conn = $self->instance->connect('conn') or return $self->_error('failed to connect');
+      my $conn = $self->instance->connect('conn') or return $self->_error('failed to connect');
 
-    $conn->quiet_next_error if $self->quiet_error;
-    $conn->prepSequence() or confess 'Failed to prepare sequence';
+      $conn->quiet_next_error if $self->quiet_error;
+      $conn->prepSequence() or confess 'Failed to prepare sequence';
 
-    my $rows = $conn->do( $self->sql ) or return $self->quiet_error ? undef : $self->_error("error: Insert failed - $DBI::errstr");
+      my $rows = $conn->do( $self->sql ) or return $self->quiet_error ? undef : $self->_error("Insert failed: $DBI::errstr");
 
-    # Tiny optimization: if we are being executed in a void context, then we
-    # don't care about the sequence value. save the round trip and reduce latency.
-    return 1 if $params{void};
+      # Tiny optimization: if we are being executed in a void context, then we
+      # don't care about the sequence value. save the round trip and reduce latency.
+      return 1 if $params{void};
 
-    my ($sequenceval) = $conn->getSequenceValue();
+      my ($sequenceval) = $conn->getSequenceValue();
 
-    return $sequenceval;
+      return $sequenceval;
 
 }
 

--- a/lib/DBR/Query/Part/Value.pm
+++ b/lib/DBR/Query/Part/Value.pm
@@ -52,7 +52,7 @@ sub new{
                 my @tv = $trans->backward($_);
 
                 # undef is ok... but we Must have at least one element, or we are bailing
-                scalar(@tv) or $self->_error('invalid: invalid value');
+                scalar(@tv) or $self->_error('invalid value');
                 push @translated, @tv;
             }
             $value = \@translated;
@@ -62,7 +62,7 @@ sub new{
         my $testsub = $field->testsub or confess 'failed to retrieve testsub';
 
         foreach (@$value) {
-            $testsub->($_) or $self->_error('invalid: invalid value');
+            $testsub->($_) or $self->_error('invalid value');
         }
 
     }else{
@@ -73,7 +73,7 @@ sub new{
         if ( $self->{is_number} ) {
             foreach my $val ( @{$value}) {
                 $val = '' unless defined $val;
-                looks_like_number($val) or $self->_error('invalid: value is not a legal number');
+                looks_like_number($val) or $self->_error('value is not a legal number');
             }
         }
     }

--- a/lib/DBR/Query/Part/Value.pm
+++ b/lib/DBR/Query/Part/Value.pm
@@ -13,74 +13,74 @@ use Carp;
 #### Constructors ###############################################
 
 sub new{
-      my( $package ) = shift;
-      my %params = @_;
+    my( $package ) = shift;
+    my %params = @_;
 
-      my $field = $params{field}; # optional
+    my $field = $params{field}; # optional
 
 
-      my $self = {
-		  session => $params{session},
-		  field  => $field
-		 };
+    my $self = {
+        session => $params{session},
+        field  => $field
+    };
 
-      bless( $self, $package );
+    bless( $self, $package );
 
-      if (defined $field){ #field object is optional
-	    ref($field) eq 'DBR::Config::Field' or croak 'invalid field object';
-      }
+    if (defined $field) {       #field object is optional
+        ref($field) eq 'DBR::Config::Field' or croak 'invalid field object';
+    }
 
-      exists($params{value}) || croak 'value must be specified'; # undef and 0 are both legal, so cannot check for defined or truth
-      my $value = $params{value};
+    exists($params{value}) || croak 'value must be specified'; # undef and 0 are both legal, so cannot check for defined or truth
+    my $value = $params{value};
 
-      if ( ref($value) eq 'DBR::Util::Operator' ) {
-	    my $wrapper = $value;
+    if ( ref($value) eq 'DBR::Util::Operator' ) {
+        my $wrapper = $value;
 
-	    $value   = $wrapper->value;
-	    $self->{op_hint} = $wrapper->operator;
-      }
+        $value   = $wrapper->value;
+        $self->{op_hint} = $wrapper->operator;
+    }
 
-      $value = [$value] unless ref($value) eq 'ARRAY';
+    $value = [$value] unless ref($value) eq 'ARRAY';
 
-      if(ref($field) eq 'DBR::Config::Field'){ # No Anon
+    if (ref($field) eq 'DBR::Config::Field') { # No Anon
 
-	    my $trans = $field->translator;
-	    if($trans){
+        my $trans = $field->translator;
+        if ($trans) {
 
-		  my @translated;
-		  foreach (@$value){
-			my @tv = $trans->backward($_);
+            my @translated;
+            foreach (@$value) {
+                my @tv = $trans->backward($_);
 
-			# undef is ok... but we Must have at least one element, or we are bailing
-			scalar(@tv) or croak 'invalid value ' . (defined($_)?"'$_'":'undef') . ' for field ' . $field->name . ' (translator)';
-			push @translated, @tv;
-		  }
-		  $value = \@translated;
-	    }
-	    $self->{is_number}  = $field->is_numeric;
+                # undef is ok... but we Must have at least one element, or we are bailing
+                scalar(@tv) or $self->_error('invalid: invalid value');
+                push @translated, @tv;
+            }
+            $value = \@translated;
+        }
+        $self->{is_number}  = $field->is_numeric;
 
-	    my $testsub = $field->testsub or confess 'failed to retrieve testsub';
+        my $testsub = $field->testsub or confess 'failed to retrieve testsub';
 
-	    foreach (@$value){
-		 $testsub->($_) or croak 'invalid value ' . (defined($_)?"'$_'":'undef') . ' for field ' . $field->name;
-	    }
+        foreach (@$value) {
+            $testsub->($_) or $self->_error('invalid: invalid value');
+        }
 
-      }else{
-	    defined($params{is_number}) or croak 'is_number must be specified';
+    }else{
+        defined($params{is_number}) or croak 'is_number must be specified';
 
-	    $self->{is_number}  = $params{is_number}? 1 : 0;
+        $self->{is_number}  = $params{is_number}? 1 : 0;
 
-	    if( $self->{is_number} ){
-		  foreach my $val ( @{$value}) {
-			$val = '' unless defined $val;
-			looks_like_number($val) or croak "value '$val' is not a legal number";
-		  }
-	    }
-      }
+        if ( $self->{is_number} ) {
+            foreach my $val ( @{$value}) {
+                $val = '' unless defined $val;
+                looks_like_number($val) or $self->_error('invalid: value is not a legal number');
+            }
+        }
+    }
 
-      $self->{value}    = $value;
+    $self->{value}    = $value;
 
-      return $self;
+    return $self;
 
 }
 
@@ -93,28 +93,28 @@ sub is_number{ return $_[0]->{is_number}             }
 sub count    { return scalar(  @{ $_[0]->{value} } ) }
 
 sub sql {
-      my $self = shift;
-      my $conn = shift or croak 'conn is required';
+    my $self = shift;
+    my $conn = shift or croak 'conn is required';
 
-      my $sql;
+    my $sql;
 
-      my $values = $self->quoted($conn);
+    my $values = $self->quoted($conn);
 
-      if (@$values != 1) {
-	    $sql .= '(' . join(',',@{$values}) . ')';
-      } elsif(@$values == 1){
-	    $sql = $values->[0];
-      }
+    if (@$values != 1) {
+        $sql .= '(' . join(',',@{$values}) . ')';
+    }elsif (@$values == 1){
+        $sql = $values->[0];
+    }
 
-      return $sql;
+    return $sql;
 
 }
 
 sub is_null{
-      my $self = shift;
+    my $self = shift;
 
-      return 1 if $self->count == 1 and !defined( $self->{value}->[0] );
-      return 0;
+    return 1 if $self->count == 1 and !defined( $self->{value}->[0] );
+    return 0;
 }
 
 sub with_value {
@@ -125,19 +125,17 @@ sub with_value {
 sub is_emptyset{ $_[0]->count == 0 }
 
 sub quoted{
-      my $self = shift;
-      my $conn = shift or croak('conn is required');
+    my $self = shift;
+    my $conn = shift or croak('conn is required');
 
-      if ($self->is_number){
-	    return [ map { defined($_)?$_:'NULL' } @{$self->{value}} ];
-      }else{
-	    return [ map { defined($_)?$_:'NULL' } map { $conn->quote($_) } @{$self->{value}} ];
-      }
+    if ($self->is_number) {
+        return [ map { defined($_)?$_:'NULL' } @{$self->{value}} ];
+    }else{
+        return [ map { defined($_)?$_:'NULL' } map { $conn->quote($_) } @{$self->{value}} ];
+    }
 
 }
 
 sub raw{ wantarray?@{ $_[0]->{value} } : $_[0]->{value} }
 
 sub _session { $_[0]->{session} }
-
-


### PR DESCRIPTION
Code prefixing allows more specific error logging separated from general crashes.  Remove values from message for security reasons.