### PR TITLE
Engage CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: perl:5.28.1
+    steps:
+      - checkout
+      - run:
+          name: "Install CPAN dependencies and build"
+          command: |
+            export PERL_MM_USE_DEFAULT=1
+            cpan App::mymeta_requires
+            perl Makefile.PL
+            cpan $(mymeta-requires)
+            make
+      - run:
+          name: "Run Test Suite"
+          command: |
+            make test
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,5 +37,8 @@ WriteMakefile(
 				  'Time::ParseDate'    => 0,
 				  'Text::SimpleTable::AutoWidth' => 0
 				 },
+	      TEST_REQUIRES   => {
+				  'Test::Exception'    => 0,
+				 },
 
 	     );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,6 @@ WriteMakefile(
               EXE_FILES    => [qw'bin/dbr-admin bin/dbr-dump-spec bin/dbr-load-spec bin/dbr-scan-db bin/dbr-config'],
 	      PREREQ_PM       => {
 				  'Carp'               => 0,
-				  'Class::Std'         => 0,
 				  'Clone'              => 0,
 				  'Curses::UI'         => 0,
 				  'Data::Dumper'       => 0,


### PR DESCRIPTION
Create a basic CircleCI config using the Perl 5.28.1 Docker image.

Install CPAN deps based on the Makefile.PL specification using `App::mymeta_requires`.  Update the dependency specifications.