### PR TITLE
Fix date parsing shortcomings

### DIFF
--- a/lib/DBR/Config/Trans/DateTime.pm
+++ b/lib/DBR/Config/Trans/DateTime.pm
@@ -8,6 +8,7 @@ use strict;
 
 use base 'DBR::Config::Trans';
 use DBR::Config::Trans::UnixTime;
+use DBR::Util::Date;
 use POSIX qw(strftime);
 
 sub init {
@@ -20,7 +21,7 @@ sub forward{
       my $self  = shift;
       my $value = shift;
       
-      my $unixtime = Time::ParseDate::parsedate($value);
+      my $unixtime = DBR::Util::Date::to_unixtime($value);
       return bless( [$unixtime,$self->{tzref}] , 'DBR::_UXTIME');
 }
 
@@ -39,7 +40,7 @@ sub backward{
         $unixtime = $value;
         
     }else{
-        $unixtime = Time::ParseDate::parsedate($value);
+        $unixtime = DBR::Util::Date::to_unixtime($value);
 
         unless($unixtime){
           $self->_error("Invalid time '$value'");

--- a/lib/DBR/Config/Trans/UnixTime.pm
+++ b/lib/DBR/Config/Trans/UnixTime.pm
@@ -8,9 +8,9 @@ package DBR::Config::Trans::UnixTime;
 use strict;
 use base 'DBR::Config::Trans';
 use strict;
-#use Date::Parse ();
-use Time::ParseDate ();
+
 use POSIX qw(strftime tzset);
+use DBR::Util::Date;
 
 sub new { die "Should not get here" }
 
@@ -41,13 +41,8 @@ sub backward{
       }else{
 	    local($ENV{TZ}) = ${$self->{tzref}}; tzset(); # Date::Parse doesn't accept timezone in the way we want to specify it. Lame.
 
-	    # Ok... so Date::Parse is kinda cool and all, except for the fact that it breaks horribly on
-	    # Non DST-specific timezone prefixes, like PT, MT, CT, ET. Treats them all like GMT.
-	    # Even strptime freaks out on it. What gives Graham? 
-	    # P.S. glass house here throwing stones, but try adding a comment or two.
+        my $uxtime = DBR::Util::Date::to_unixtime($value);
 
-	    #my $uxtime = Date::Parse::str2time($value);
-	    my $uxtime = Time::ParseDate::parsedate($value);
 
 	    unless($uxtime){
 		  $self->_error("Invalid time '$value'");

--- a/lib/DBR/Util/Date.pm
+++ b/lib/DBR/Util/Date.pm
@@ -1,0 +1,31 @@
+# the contents of this file are Copyright (c) 2009-2011 Daniel Norman
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation.
+
+package DBR::Util::Date;
+use strict;
+
+#use Date::Parse ();
+use Time::ParseDate ();
+
+sub to_unixtime {
+    my ($value) = @_;
+
+    # Ok... so Date::Parse is kinda cool and all, except for the fact that it breaks horribly on
+    # Non DST-specific timezone prefixes, like PT, MT, CT, ET. Treats them all like GMT.
+    # Even strptime freaks out on it. What gives Graham?
+    # P.S. glass house here throwing stones, but try adding a comment or two.
+
+    #my $uxtime = Date::Parse::str2time($value);
+
+    # parsedate truncates the h/m/s when the value is iso8601 with timezones
+    # e.g., 2017-09-22T11:24:41-06:00 or 2017-09-22T11:24:41Z
+    # However, it properly parses if a space is inserted between the seconds and timezone
+    $value =~ s/([+-]\d{2}:?\d{2})$/ $1/;
+    $value =~ s/Z$/ Z/;
+
+    return Time::ParseDate::parsedate($value);
+}
+
+1;

--- a/t/10_translators.t
+++ b/t/10_translators.t
@@ -24,18 +24,67 @@ my %ALBUMDATES = (
 my $artists = $dbh->artist->all();
 ok( defined($artists) , 'select all artists');
 
+my $one_artist;
 while (my $artist = $artists->next()) {
+    $one_artist ||= $artist;
+
     my ($refdate,$datetime);
     ok ( $refdate  =  $ALBUMDATES{$artist->name} , 'datetime - reference date');
     ok ( $datetime =  $artist->date_founded,       'datetime - date_founded ' );
     ok ( $datetime == $refdate,                    'date verification');
     diag($datetime);
-    
-    ok ( $artist->date_founded('2001-02-03 04:05:06'),    'datetime - update' );
-    ok ( $artist->date_founded('midnight Last Tuesday'),  'datetime - update' );
-    ok ( $artist->date_founded('next sunday'),  'datetime - update' );
 }
 
+ok ( $one_artist->date_founded('2001-02-03 04:05:06'),    'datetime - update' );
+ok ( $one_artist->date_founded('midnight Last Tuesday'),  'datetime - update' );
+ok ( $one_artist->date_founded('next sunday'),  'datetime - update' );
 
+my $expected_unixtime = 981173106;
+ok ( $one_artist->date_founded('2001-02-03T04:05:06'), 'datetime - update w/ iso8601 (no tz)' );
+is (
+    $one_artist->date_founded->unixtime,
+    $expected_unixtime,
+    'datetime recorded properly from iso8601 (no tz)',
+);
+
+ok (
+    $one_artist->date_founded('2001-02-03T04:05:06-00:00'),
+    'datetime - update w/ iso8601 (w/ utc tz)',
+);
+is (
+    $one_artist->date_founded->unixtime,
+    $expected_unixtime,
+    'datetime recorded properly from iso8601 (w/ utc tz)',
+);
+
+ok (
+    $one_artist->date_founded('2001-02-02T21:05:06-07:00'),
+    'datetime - update w/ iso8601 (w/ pdt tz)',
+);
+is (
+    $one_artist->date_founded->unixtime,
+    $expected_unixtime,
+    'datetime recorded properly from iso8601 (w/ pdt tz)',
+);
+
+ok (
+    $one_artist->date_founded('2001-02-02T21:05:06-0700'),
+    'datetime - update w/ iso8601 (w/ no-colon tz)',
+);
+is (
+    $one_artist->date_founded->unixtime,
+    $expected_unixtime,
+    'datetime recorded properly from iso8601 (w/ no-colon tz)',
+);
+
+ok (
+    $one_artist->date_founded('2001-02-03T04:05:06Z'),
+    'datetime - update w/ iso8601 (w/ zulu tz)',
+);
+is (
+    $one_artist->date_founded->unixtime,
+    $expected_unixtime,
+    'datetime recorded properly from iso8601 (w/ zulu tz)',
+);
 
 done_testing();


### PR DESCRIPTION
The currently-used date parsing method (`Time::ParseDate::parsedate`) truncates the h/m/s from the parsed unixtime when the input value is iso8601 with timezones.  E.g., `2017-09-22T05:24:41-06:00` or `2017-09-22T11:24:41Z` parse into the unixtime equivalent of `2017-09-22 00:00:00 UTC`.

This PR creates a utility module that parses such dates properly.  Updating the repo to use a local utility module has the advantage of creating a single location that has to be updated for further fixups or wholesale replacement of the external library being used (which may be prudent at some point, but sticking with the currently-used library minimizes risk of breakage).
