### PR TITLE
Support for nowait queries

### DIFF
--- a/lib/DBR/Config/Instance.pm
+++ b/lib/DBR/Config/Instance.pm
@@ -298,8 +298,11 @@ sub _new_connection{
       my $config = $INSTANCES_BY_GUID{ $self->{guid} };
       my @params = ($config->{connectstring}, $config->{user}, $config->{password});
 
-      my $dbh = DBI->connect(@params) or
-	return $self->_error("Error: Failed to connect to db $config->{handle},$config->{class}");
+      my $dbh = DBI->connect(@params);
+      unless ($dbh) {
+          $self->_log("DBI error attempting to connect to db $config->{handle},$config->{class}: $DBI::errstr");
+          return $self->_error("Error: Failed to connect to db $config->{handle},$config->{class}");
+      }
 
       my $connclass = $config->{connclass};
 

--- a/lib/DBR/Query.pm
+++ b/lib/DBR/Query.pm
@@ -120,6 +120,15 @@ sub offset{
   return $self;
 }
 
+sub optimizer_hints {
+    my $self = shift;
+
+    exists( $_[0] ) or return $self->{optimizer_hints};
+    $self->{optimizer_hints} = shift;
+
+    return $self;
+}
+
 sub _limit_clause {
     my $self = shift;
     my ($limit, $offset) = @{ $self }{ 'limit', 'offset' };

--- a/lib/DBR/Query/Delete.pm
+++ b/lib/DBR/Query/Delete.pm
@@ -20,10 +20,11 @@ sub sql{
 
       my $conn   = $self->instance->connect('conn') or return $self->_error('failed to connect');
       my $sql;
+      my $optimizer_hints = $self->optimizer_hints ? $self->optimizer_hints->sql($conn) : '';
       my $tables = join(',', map { $_->sql( $conn ) } @{$self->{tables}} );
       my $sets   = join(',', map { $_->sql( $conn ) } @{$self->{sets}}   );
 
-      $sql = "DELETE FROM $tables";
+      $sql = "DELETE ${optimizer_hints}FROM $tables";
       $sql .= ' WHERE ' . $self->{where}->sql($conn) if $self->{where};
       $sql .= ' LIMIT ' . $self->_limit_clause       if $self->{limit} || $self->{offset};
 

--- a/lib/DBR/Query/Insert.pm
+++ b/lib/DBR/Query/Insert.pm
@@ -75,6 +75,7 @@ sub sql{
 
       my $conn   = $self->instance->connect('conn') or return $self->_error('failed to connect');
       my $sql;
+      my $optimizer_hints = $self->optimizer_hints ? $self->optimizer_hints->sql($conn) : '';
       my $tables = join(',', map {$_->sql($conn)} @{$self->{tables}} );
 
       my @fields;
@@ -84,7 +85,7 @@ sub sql{
 	    push @values, $_->value->sql( $conn );
       }
 
-      $sql = "INSERT INTO $tables (" . join (', ', @fields) . ') values (' . join (', ', @values) . ')';
+      $sql = "INSERT INTO $optimizer_hints$tables (" . join (', ', @fields) . ') values (' . join (', ', @values) . ')';
 
       $sql .= ' WHERE ' . $self->{where}->sql( $conn ) if $self->{where};
       $sql .= ' FOR UPDATE'                            if $self->{lock} && $conn->can_lock;

--- a/lib/DBR/Query/Part/OptimizerHints.pm
+++ b/lib/DBR/Query/Part/OptimizerHints.pm
@@ -7,7 +7,26 @@
 package DBR::Query::Part::OptimizerHints;
 
 use strict;
+
+=head1 NAME
+
+DBR::Query::Part::OptimizerHints
+
+=head1 SYNOPSIS
+
+Support for MySQL optimizer hints.
+
+=cut
+
 use base 'DBR::Query::Part';
+
+=head1 CONSTRUCTOR
+
+=head2 new(@hints)
+
+Create object to hold optimizer hints.  Can privide C<@hints> list now or use C<push> later.
+
+=cut
 
 sub new {
     my $package = shift;
@@ -19,6 +38,12 @@ sub new {
     return bless([@_], $package);
 }
 
+=head2 $optimizer_hints->push($hint)
+
+Add C<$hint> to list of optimizer hints.
+
+=cut
+
 sub push {
     my ($self, $hint) = @_;
 
@@ -26,6 +51,12 @@ sub push {
 
     return $self;
 }
+
+=head2 children(@hints_to_set)
+
+Gets list of hints if no argument is provided or sets list of hints, if provided.
+
+=cut
 
 sub children {
     my ($self, @hints_to_set) = @_;
@@ -38,6 +69,12 @@ sub children {
 
     return @$self;
 }
+
+=head2 sql
+
+Generate SQL for optimizer hints in this object.
+
+=cut
 
 sub sql {
     my ($self, $conn) = @_;

--- a/lib/DBR/Query/Part/OptimizerHints.pm
+++ b/lib/DBR/Query/Part/OptimizerHints.pm
@@ -1,0 +1,57 @@
+# the contents of this file are Copyright (c) 2009 Daniel Norman
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation.
+
+###########################################
+package DBR::Query::Part::OptimizerHints;
+
+use strict;
+use base 'DBR::Query::Part';
+
+sub new {
+    my $package = shift;
+
+    foreach my $hint (@_) {
+        _validate_hint($package, $hint);
+    }
+
+    return bless([@_], $package);
+}
+
+sub push {
+    my ($self, $hint) = @_;
+
+    $self->children($self->children, $hint);
+
+    return $self;
+}
+
+sub children {
+    my ($self, @hints_to_set) = @_;
+
+    if (@hints_to_set) {
+        _validate_hint($self, $_) for @hints_to_set;
+
+        @$self = @hints_to_set;
+    }
+
+    return @$self;
+}
+
+sub sql {
+    my ($self, $conn) = @_;
+
+    return '/*+ ' . join(' ', map { $_->sql($conn) } $self->children) . ' */ ';
+}
+
+sub _validate_hint {
+    my ($package_or_self, $hint) = @_;
+
+    ref($hint) =~ /^DBR::Query::Part::OptimizerHints::/
+        or $package_or_self->_error("Must be an optimizer hint type");
+
+    return;
+}
+
+1;

--- a/lib/DBR/Query/Part/OptimizerHints/MaxExecutionTime.pm
+++ b/lib/DBR/Query/Part/OptimizerHints/MaxExecutionTime.pm
@@ -1,0 +1,30 @@
+# the contents of this file are Copyright (c) 2009 Daniel Norman
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation.
+
+###########################################
+package DBR::Query::Part::OptimizerHints::MaxExecutionTime;
+
+use strict;
+use base 'DBR::Query::Part::OptimizerHints';
+
+sub new {
+    my ($package, $millisecond_limit) = @_;
+
+    $package->_error('positive execution limit (milliseconds) required')
+        unless 0 + $millisecond_limit > 0;
+
+    return bless(\$millisecond_limit, $package);
+}
+
+
+sub sql { return 'MAX_EXECUTION_TIME(' . _millisecond_limit($_[0]) . ')' }
+
+sub _millisecond_limit { return ${$_[0]} }
+
+# _validate_self doesn't get called unless the query part is provided at query
+#  object creation, thus we validate in new
+sub _validate_self { 1 }
+
+1;

--- a/lib/DBR/Query/Part/OptimizerHints/MaxExecutionTime.pm
+++ b/lib/DBR/Query/Part/OptimizerHints/MaxExecutionTime.pm
@@ -7,7 +7,28 @@
 package DBR::Query::Part::OptimizerHints::MaxExecutionTime;
 
 use strict;
+
+=head1 NAME
+
+DBR::Query::Part::OptimizerHints::MaxExecutionTime
+
+=head1 SYNOPSIS
+
+Support for MAX_EXECUTION_TIME optimizer hint that limits the time that MySQL
+will spend executing a query before throwing an error.  Generally useful if
+you don't want to wait for locks to resolve.
+
+=cut
+
 use base 'DBR::Query::Part::OptimizerHints';
+
+=head1 CONSTRUCTOR
+
+=head2 new($millisecond_limit)
+
+Create hint with C<$millisecond_limit> max execution time limit.
+
+=cut
 
 sub new {
     my ($package, $millisecond_limit) = @_;
@@ -18,6 +39,11 @@ sub new {
     return bless(\$millisecond_limit, $package);
 }
 
+=head2 sql
+
+Generate SQL for this optimizer hint.
+
+=cut
 
 sub sql { return 'MAX_EXECUTION_TIME(' . _millisecond_limit($_[0]) . ')' }
 

--- a/lib/DBR/Query/Update.pm
+++ b/lib/DBR/Query/Update.pm
@@ -35,10 +35,11 @@ sub sql{
 
       my $conn   = $self->instance->connect('conn') or return $self->_error('failed to connect');
       my $sql;
+      my $optimizer_hints = $self->optimizer_hints ? $self->optimizer_hints->sql($conn) : '';
       my $tables = join(',', map { $_->sql( $conn ) } @{$self->{tables}} );
       my $sets   = join(',', map { $_->sql( $conn ) } @{$self->{sets}}   );
 
-      $sql = "UPDATE $tables SET $sets";
+      $sql = "UPDATE $optimizer_hints$tables SET $sets";
       $sql .= ' WHERE ' . $self->{where}->sql($conn) if $self->{where};
       $sql .= ' LIMIT ' . $self->_limit_clause       if $self->{limit} || $self->{offset};
 

--- a/lib/DBR/ResultSet.pm
+++ b/lib/DBR/ResultSet.pm
@@ -267,7 +267,7 @@ sub set {
 
 	     $value->count == 1 or croak("Field $name allows only a single value");
 
-	     my $setobj   = DBR::Query::Part::Set->new( $field, $value ) or return $self->_error('failed to create set object');
+         my $setobj   = DBR::Query::Part::Set->new( $field, $value ) or return $self->_error('failed to create set object');
 
 	     push @sets, $setobj;
        };
@@ -310,8 +310,6 @@ sub force_index {
     $self->[f_query]->force_index($index_name);
     return $self;
 }
-
-
 
 sub order_by {
     my $self = shift;
@@ -441,5 +439,7 @@ sub _lookuphash{
 
       return \%lookup;
 }
+
+sub _session { $_[0][f_query]->_session }
 
 1;

--- a/t/18_nowait.t
+++ b/t/18_nowait.t
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use lib './lib';
+use t::lib::Test;
+use Test::More;
+use DBI::Const::GetInfoType;
+
+my $resultset = setup_schema_ok('music')->connect('music')->album->all;
+my $query = $resultset->[3];
+my $conn = $query->instance->getconn;
+
+{
+    my $dbms_name = $conn->{dbh}->get_info($GetInfoType{SQL_DBMS_NAME});
+    my $dbms_version = $conn->{dbh}->get_info($GetInfoType{SQL_DBMS_VER});
+
+    like
+        $query->sql,
+        qr,SELECT\s+"album_id"\s+FROM\s+"album",i,
+        "$dbms_name $dbms_version: nowait not set yet";
+
+    $resultset->nowait(1);
+
+    like
+        $query->sql,
+        qr,SELECT\s+"album_id"\s+FROM\s+"album",i,
+        "$dbms_name $dbms_version: no nowait support";
+}
+
+{
+    # Fake MySQL 5.7 database handle
+    my $method = ref($conn->{dbh}) . '::get_info';
+    no strict 'refs';
+    no warnings;
+    local *{$method} = sub {
+        my ($pkg, $info_field) = @_;
+
+        return 'MySQL'
+            if $info_field == $GetInfoType{SQL_DBMS_NAME};
+
+        return '5.7'
+            if $info_field == $GetInfoType{SQL_DBMS_VER};
+
+        return;
+    };
+    use strict 'refs';
+    use warnings;
+
+    my $dbms_name = $conn->{dbh}->get_info($GetInfoType{SQL_DBMS_NAME});
+    my $dbms_version = $conn->{dbh}->get_info($GetInfoType{SQL_DBMS_VER});
+
+    $resultset->nowait(1);
+    my $regex = 'SELECT\s+/\*\+\s+MAX_EXECUTION_TIME\(' . DBR::ResultSet::MIN_MAX_EXECUTION_TIME . '\)\s+\*/\s+"album_id"\s+FROM\s+"album"';
+
+    like
+        $query->sql,
+        qr,$regex,i,
+        "$dbms_name $dbms_version: max execution time hint with min timeout";
+
+    $resultset->nowait(100);
+
+    like
+        $query->sql,
+        qr,SELECT\s+/\*\+\s+MAX_EXECUTION_TIME\(100\)\s+\*/\s+"album_id"\s+FROM\s+"album",i,
+        "$dbms_name $dbms_version: max execution time hint with higher custom timeout";
+}
+
+done_testing();


### PR DESCRIPTION
Support for nowait queries, i.e., immediately return an error when attempting to select a locked record instead of waiting for the lock to be released.

Note that the first two commits are while-you're-at-it fixes.

## Related PRs
gudtech/gt-core#213
gudtech/gt-processor#101