### PR TITLE
[ROP-7555] Allow querying and setting of enums by id

### DIFF
--- a/example/schemas/music/spec
+++ b/example/schemas/music/spec
@@ -1,4 +1,7 @@
 schema=music	table=artist	field=royalty_rate	cmd=TRANSLATOR	translator=PERCENT
+schema=music	table=artist	field=genre	cmd=TRANSLATOR	translator=ENUM
+schema=music	table=artist	field=genre	cmd=ENUMOPT	handle=rock	override_id=10	name=Rock
+schema=music	table=artist	field=genre	cmd=ENUMOPT	handle=blues	override_id=20	name=Blues
 schema=music	table=album	field=artist_id	cmd=RELATION	reltable=artist	relfield=artist_id	relname=artist	reverse_name=albums	type=CHILDOF
 schema=music	table=album	field=rating	cmd=TRANSLATOR	translator=ENUM
 schema=music	table=album	field=rating	cmd=ENUMOPT	handle=lv_evry_sec	override_id=100	name=Loved Every Second

--- a/example/schemas/music/sql
+++ b/example/schemas/music/sql
@@ -2,7 +2,7 @@
 CREATE TABLE artist (
   artist_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   name varchar(250),
-  genre int,
+  genre smallint unsigned,
   status int,
   royalty_rate double,
   date_founded datetime

--- a/lib/DBR/Config/Trans/Enum.pm
+++ b/lib/DBR/Config/Trans/Enum.pm
@@ -109,9 +109,10 @@ sub backward{
 
       my @out;
       foreach ( $self->_split($value) ){
-	    #otherwise hit the lookup
-	    my $id =  $FIELDMAP{ $self->{field_id} }->[ x_hmap ]->{ $_ }->[ v_id ];
-	    return () unless defined($id);
+        #otherwise hit the lookup
+        my $id = $FIELDMAP{ $self->{field_id} }->[ x_hmap ]->{ $_ }->[ v_id ]
+            // $FIELDMAP{ $self->{field_id} }->[ x_idmap ]->{ $_ }->[ v_id ];
+        return () unless defined($id);
 
 	    push @out, $id;
       }

--- a/t/10_translators.t
+++ b/t/10_translators.t
@@ -87,4 +87,16 @@ is (
     'datetime recorded properly from iso8601 (w/ zulu tz)',
 );
 
+my $album = $dbh->album->where( rating => 'fair' )->next;
+is $album->rating->handle, 'fair', 'query by enum handle';
+
+$album = $dbh->album->where( rating => 500 )->next;
+is $album->rating->handle, 'fair', 'query by enum id';
+
+$album->rating('sucks');
+is $album->rating->handle, 'sucks', 'set enum with handle';
+
+$album->rating(600);
+is $album->rating->handle, 'poor', 'set enum with id';
+
 done_testing();


### PR DESCRIPTION
Currently, if a field is set to use an enum translator, you can only query and set values using the enum handle.  This prevents transitioning existing fields from non-translated to enum translated without downtime.  This PR allows querying and setting of enum values using the enum id, which will allow existing id-specified code to continue to work for fields that get updated to be enum translated.