### PR TITLE
Fix DBR::Misc::DBI::Compat dying on read-only row buffers

### DIFF
--- a/lib/DBR/Misc/DBI/Compat.pm
+++ b/lib/DBR/Misc/DBI/Compat.pm
@@ -14,10 +14,11 @@ package DBR::Misc::DBI::Compat::st;
 use parent -norequire, 'DBI::st';
 
 sub fetchrow_arrayref {
+    # DBD::mysql returns a reused internal row buffer whose AV is flagged
+    # SvREADONLY, so assigning back into @$row dies. Build a fresh arrayref.
     my $row = $_[0]->SUPER::fetchrow_arrayref;
     return undef unless $row;
-    @$row = map { defined $_ ? "$_" : $_ } @$row;
-    return $row;
+    return [ map { defined $_ ? "$_" : $_ } @$row ];
 }
 
 *fetch = \&fetchrow_arrayref;
@@ -40,15 +41,14 @@ sub fetchall_arrayref {
     my $rows  = $self->SUPER::fetchall_arrayref(@_);
     return $rows unless $rows && @$rows;
     if ( ref($slice) eq 'HASH' ) {
+        # Hash slot assignment replaces the SV, so in-place is safe here.
         for my $row (@$rows) {
             $row->{$_} = "$row->{$_}" for grep { defined $row->{$_} } keys %$row;
         }
-    } else {
-        for my $row (@$rows) {
-            @$row = map { defined $_ ? "$_" : $_ } @$row;
-        }
+        return $rows;
     }
-    return $rows;
+    # Row AVs may be SvREADONLY (see fetchrow_arrayref); build fresh arrayrefs.
+    return [ map { [ map { defined $_ ? "$_" : $_ } @$_ ] } @$rows ];
 }
 
 sub fetchall_hashref {

--- a/t/rt_rop9213.t
+++ b/t/rt_rop9213.t
@@ -1,0 +1,55 @@
+#!/usr/bin/perl
+
+# Regression test for ROP-9213: DBR::Misc::DBI::Compat must not write back
+# into the row buffer returned by SUPER::fetchrow_arrayref, because some
+# DBD drivers (notably DBD::mysql) flag those scalars SvREADONLY.
+
+use strict;
+use warnings;
+$| = 1;
+
+use Test::More tests => 7;
+
+# Fake DBI::st parent that hands back arrayrefs whose AV is flagged
+# SvREADONLY, mimicking DBD::mysql's reused-internal-buffer behavior.
+# Compat::st uses `use parent -norequire, 'DBI::st'`, so we can populate
+# DBI::st freely without actually loading DBI.
+{
+    package DBI::st;
+    our @row_queue;
+    sub fetchrow_arrayref {
+        return undef unless @row_queue;
+        my $row = shift @row_queue;
+        Internals::SvREADONLY(@$row, 1);
+        return $row;
+    }
+    sub fetchall_arrayref {
+        my @out;
+        while (my $r = DBI::st::fetchrow_arrayref()) { push @out, $r }
+        return \@out;
+    }
+}
+
+use_ok('DBR::Misc::DBI::Compat');
+
+my $sth = bless {}, 'DBR::Misc::DBI::Compat::st';
+
+# fetchrow_arrayref: must survive read-only elements and stringify defined values
+@DBI::st::row_queue = ([1, 2, 'three'], [undef, 'x']);
+
+my $r1 = eval { $sth->fetchrow_arrayref };
+is($@, '', 'fetchrow_arrayref does not die on read-only row buffer');
+is_deeply($r1, ['1', '2', 'three'], 'defined values stringified');
+
+my $r2 = eval { $sth->fetchrow_arrayref };
+is_deeply($r2, [undef, 'x'], 'undef preserved, defined stringified');
+
+# fetchall_arrayref (array-slice path): same read-only safety
+@DBI::st::row_queue = ([42, 'a'], [99, 'b']);
+my $all = eval { $sth->fetchall_arrayref };
+is($@, '', 'fetchall_arrayref does not die on read-only row buffers');
+is_deeply($all, [['42','a'],['99','b']], 'all rows stringified');
+
+# Returned arrayref must itself be writable (not the SUPER buffer)
+eval { $all->[0][0] = 'mutable' };
+is($@, '', 'returned row is a fresh, writable arrayref');


### PR DESCRIPTION
## Summary

- **`lib/DBR/Misc/DBI/Compat.pm`**: `fetchrow_arrayref` and the array-slice path of `fetchall_arrayref` now return a freshly allocated arrayref instead of reassigning into `@$row`. Hash-slice paths are unchanged — hash slot assignment replaces the SV and is safe regardless of source AV flags.
- **`t/rt_rop9213.t`** (new): standalone regression test that mocks `DBI::st` to hand back row arrayrefs whose AV is flagged `SvREADONLY`, reproducing the production error on master and passing with the fix.

## Background

After #17 merged, services using the new shim started dying with:

```
Modification of a read-only value attempted at /service/main/perl-DBR/lib/DBR/Misc/DBI/Compat.pm line 19
```

Line 19 was `@$row = map { defined $_ ? "$_" : $_ } @$row;`. `DBD::mysql`'s `fetchrow_arrayref` returns a reused internal row buffer whose **AV itself** is flagged `SvREADONLY` (not the individual scalars — verified empirically: `Internals::SvREADONLY(@arr, 1)` triggers the same croak on `@$arr = ...`, while flagging the elements does not). Building a fresh arrayref sidesteps the issue entirely.

The same pattern existed at line 48 in `fetchall_arrayref`'s array-slice branch — fixed the same way.

## Test plan

- [x] `prove -l t/rt_rop9213.t` passes with fix, fails on master with the exact production error
- [x] Run full perl-DBR suite in the perl-base-image-v2 container to confirm no regressions — **29 files / 537 tests / PASS**
- [ ] Redeploy a service that was hitting the error and confirm it no longer dies

## Jira ticket

https://gudtech.atlassian.net/browse/ROP-9213

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
