### PR TITLE
Tag invalid-value errors with an opaque field+value locator

### DIFF
--- a/lib/DBR/Config/Field.pm
+++ b/lib/DBR/Config/Field.pm
@@ -254,12 +254,42 @@ sub makevalue {    # shortcut function?
         );
     };
 
-    if ($@) {
-        my $field_path = $self->table->sql_instance->database . "." . $self->table->name . "." . $self->name;
-        my $want_value = ref($value) ? join ',', @$value : $value;
-        die "[$field_path -> $want_value] : $@";
+    if ( my $err = $@ ) {
+        # Opaque locator so the otherwise-anonymous "invalid value" is traceable
+        # without leaking schema names or values to outside consumers.
+        # Format:  <dbr_instances.tag>.<dbr_tables.id>.<dbr_fields.id>:<value-shape>
+        my $tag     = eval { $self->table->sql_instance->tag } || '?';
+        my $locator = sprintf '%s.%s.%s:%s',
+          $tag, ( $self->table_id // '?' ), ( $self->field_id // '?' ), _value_shape($value);
+
+        chomp $err;
+        # Insert before the "at FILE line N" so UnRPC still removes the file path & backtrace
+        unless ( $err =~ s/(\s*at .+ line \d+[.\n]*)$/ [$locator]$1/s ) {
+            $err .= " [$locator]";
+        }
+        die "$err\n";
     }
     return $value_obj;
+}
+
+# The value's SHAPE to show instead of the value itself.
+sub _value_shape {
+    my ($v) = @_;
+    return 'undef' unless defined $v;
+    if ( my $ref = ref $v ) {
+        return 'arrayref[' . scalar(@$v) . ']' if $ref eq 'ARRAY';
+        return "ref:$ref";
+    }
+    return 'empty' if $v eq '';
+    my @cls;
+    push @cls, 'digit' if $v =~ /[0-9]/;
+    push @cls, 'alpha' if $v =~ /[A-Za-z]/;
+    push @cls, 'comma' if $v =~ /,/;
+    push @cls, 'space' if $v =~ /\s/;
+    push @cls, 'dot'   if $v =~ /\./;
+    push @cls, 'dash'  if $v =~ /-/;
+    push @cls, 'other' if $v =~ /[^0-9A-Za-z,\s.\-]/;
+    return 'len' . length($v) . '_' . join( '+', @cls );
 }
 
 sub field_id     { $_[0]->[O_field_id] }

--- a/lib/DBR/Config/Field.pm
+++ b/lib/DBR/Config/Field.pm
@@ -240,17 +240,26 @@ sub clone{
 
 }
 
-sub makevalue{ # shortcut function?
-      my $self = shift;
-      my $value = shift;
+sub makevalue {    # shortcut function?
+    my $self  = shift;
+    my $value = shift;
 
-      return DBR::Query::Part::Value->new(
-					  session   => $self->[O_session],
-					  value     => $value,
-					  is_number => $self->is_numeric,
-					  field     => $self,
-					 );
+    my $value_obj;
+    eval {
+        $value_obj = DBR::Query::Part::Value->new(
+            session   => $self->[O_session],
+            value     => $value,
+            is_number => $self->is_numeric,
+            field     => $self,
+        );
+    };
 
+    if ($@) {
+        my $field_path = $self->table->sql_instance->database . "." . $self->table->name . "." . $self->name;
+        my $want_value = ref($value) ? join ',', @$value : $value;
+        die "[$field_path -> $want_value] : $@";
+    }
+    return $value_obj;
 }
 
 sub field_id     { $_[0]->[O_field_id] }


### PR DESCRIPTION
`Field::makevalue` now stamps the otherwise-anonymous `invalid value` error with an **opaque** locator:

```
invalid value [c37.225.1486:len15_digit+comma]
```

Format: `<dbr_instances.tag>.<dbr_tables.id>.<dbr_fields.id>:<value-shape>` — numeric ids + a value *shape* (length/char-classes/ref/undef), never schema names or the raw value, so it's safe for external consumers. Resolve the ids against the dbr config to recover the field.

Inserted **before** the `at FILE line N` backtrace so UnRPC's `$`-anchored strip still removes the file path and `code=internal_error` is preserved. Locator-building is guarded so it can never mask the original error.

(Rebased clean onto current master; supersedes #19, which was cut from a stale master and carried an unrelated CI commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)